### PR TITLE
512hl value net

### DIFF
--- a/src/eval/value_network.hpp
+++ b/src/eval/value_network.hpp
@@ -10,7 +10,7 @@ namespace network::value {
 
 constexpr i16 QA = 255;
 constexpr i16 QB = 64;
-constexpr usize L1_SIZE = 256;
+constexpr usize L1_SIZE = 512;
 constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;


### PR DESCRIPTION
```
Elo   | 69.39 +- 17.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 832 W: 324 L: 160 D: 348
Penta | [15, 61, 136, 153, 51]
```
https://furybench.com/test/2373/
bench: 985447