### PR TITLE
Fix indexing of promotions for policy

### DIFF
--- a/src/eval/policy_network.cpp
+++ b/src/eval/policy_network.cpp
@@ -43,14 +43,14 @@ constexpr std::array<usize, 65> OFFSETS = [] {
 
 [[nodiscard]] usize move_output_idx(Color stm, Move move) {
     const i32 flipper = stm == Color::BLACK ? 56 : 0;
+    const Square from = move.from() ^ flipper;
+    const Square to = move.to() ^ flipper;
     if (move.is_promo()) {
         constexpr usize PROMO_STRIDE = 22;
-        const i32 promo_id = 2 * move.from().file() + move.to().file();
+        const i32 promo_id = 2 * from.file() + to.file();
         const i32 kind = promo_kind_id(move.promo_type());
         return OFFSETS[64] + static_cast<usize>(kind * PROMO_STRIDE + promo_id);
     } else {
-        const Square from = move.from() ^ flipper;
-        const Square to = move.to() ^ flipper;
         const u64 all = static_cast<u64>(ALL_DESTINATIONS[from]);
         const u64 below = to == 0 ? 0ull : (all & (to.to_bb() - 1ull));
         return OFFSETS[from] + static_cast<usize>(std::popcount(below));


### PR DESCRIPTION
```
Elo   | 3.26 +- 4.38 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 9262 W: 2077 L: 1990 D: 5195
Penta | [150, 1091, 2099, 1104, 187]
```
https://furybench.com/test/2386/